### PR TITLE
Update copyright license header to new compact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
+
 # 2DP Repsymo Solver
 
 [![Project](https://raw.githubusercontent.com/repsymo/2dp-repsymo-solver/static/badge.svg)](https://repsymo.com)

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,12 +1,3 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
-
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <app-header (ioAction)="onIOAction($event)"></app-header>
 <div class="container">

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { AppComponent } from './app.component';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';

--- a/src/app/components/example-statement/example-statement.component.css
+++ b/src/app/components/example-statement/example-statement.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 div {
   margin-bottom: 16px;

--- a/src/app/components/example-statement/example-statement.component.html
+++ b/src/app/components/example-statement/example-statement.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <div [ngClass]="{ 'gone': gone }">
   <p *ngIf="!example.title">Example #{{ example.number }}</p>

--- a/src/app/components/example-statement/example-statement.component.spec.ts
+++ b/src/app/components/example-statement/example-statement.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/example-statement/example-statement.component.ts
+++ b/src/app/components/example-statement/example-statement.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/components/input/input-pane/input-pane.component.css
+++ b/src/app/components/input/input-pane/input-pane.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: block;

--- a/src/app/components/input/input-pane/input-pane.component.html
+++ b/src/app/components/input/input-pane/input-pane.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <app-time-unit-selector
   *ngIf="timeunit"

--- a/src/app/components/input/input-pane/input-pane.component.spec.ts
+++ b/src/app/components/input/input-pane/input-pane.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/input/input-pane/input-pane.component.ts
+++ b/src/app/components/input/input-pane/input-pane.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import {
   ChangeDetectorRef,

--- a/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.css
+++ b/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: block;

--- a/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.html
+++ b/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <table class="table">
   <thead>

--- a/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.spec.ts
+++ b/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.ts
+++ b/src/app/components/input/tabular-dynamic-input/tabular-dynamic-input.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/components/input/tabular-input/tabular-input.component.css
+++ b/src/app/components/input/tabular-input/tabular-input.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: block;

--- a/src/app/components/input/tabular-input/tabular-input.component.html
+++ b/src/app/components/input/tabular-input/tabular-input.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <table class="table">
   <thead>

--- a/src/app/components/input/tabular-input/tabular-input.component.spec.ts
+++ b/src/app/components/input/tabular-input/tabular-input.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/input/tabular-input/tabular-input.component.ts
+++ b/src/app/components/input/tabular-input/tabular-input.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/components/input/time-unit-selector/time-unit-selector.component.css
+++ b/src/app/components/input/time-unit-selector/time-unit-selector.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: block;

--- a/src/app/components/input/time-unit-selector/time-unit-selector.component.html
+++ b/src/app/components/input/time-unit-selector/time-unit-selector.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <div class="form-group">
   <label

--- a/src/app/components/input/time-unit-selector/time-unit-selector.component.spec.ts
+++ b/src/app/components/input/time-unit-selector/time-unit-selector.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/input/time-unit-selector/time-unit-selector.component.ts
+++ b/src/app/components/input/time-unit-selector/time-unit-selector.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { TimeUnit } from '../../../time-unit';

--- a/src/app/components/options-bar/options-bar.component.css
+++ b/src/app/components/options-bar/options-bar.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: block;

--- a/src/app/components/options-bar/options-bar.component.html
+++ b/src/app/components/options-bar/options-bar.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <i
   class="fas fa-question-circle"

--- a/src/app/components/options-bar/options-bar.component.spec.ts
+++ b/src/app/components/options-bar/options-bar.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/options-bar/options-bar.component.ts
+++ b/src/app/components/options-bar/options-bar.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/components/output/results/chain-item/chain-item.component.css
+++ b/src/app/components/output/results/chain-item/chain-item.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: inline-block;

--- a/src/app/components/output/results/chain-item/chain-item.component.html
+++ b/src/app/components/output/results/chain-item/chain-item.component.html
@@ -1,13 +1,5 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 {{ value }}

--- a/src/app/components/output/results/chain-item/chain-item.component.spec.ts
+++ b/src/app/components/output/results/chain-item/chain-item.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/output/results/chain-item/chain-item.component.ts
+++ b/src/app/components/output/results/chain-item/chain-item.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/components/output/results/chains-result/chains-result.component.css
+++ b/src/app/components/output/results/chains-result/chains-result.component.css
@@ -1,12 +1,3 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
-
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */

--- a/src/app/components/output/results/chains-result/chains-result.component.html
+++ b/src/app/components/output/results/chains-result/chains-result.component.html
@@ -1,13 +1,5 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <p>chains-result works!</p>

--- a/src/app/components/output/results/chains-result/chains-result.component.spec.ts
+++ b/src/app/components/output/results/chains-result/chains-result.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/output/results/chains-result/chains-result.component.ts
+++ b/src/app/components/output/results/chains-result/chains-result.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnInit } from '@angular/core';
 

--- a/src/app/components/output/tabular-output/tabular-output.component.css
+++ b/src/app/components/output/tabular-output/tabular-output.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: block;

--- a/src/app/components/output/tabular-output/tabular-output.component.html
+++ b/src/app/components/output/tabular-output/tabular-output.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <table class="table">
   <thead>

--- a/src/app/components/output/tabular-output/tabular-output.component.spec.ts
+++ b/src/app/components/output/tabular-output/tabular-output.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/output/tabular-output/tabular-output.component.ts
+++ b/src/app/components/output/tabular-output/tabular-output.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/components/page-documentation/page-documentation.component.css
+++ b/src/app/components/page-documentation/page-documentation.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host > div {
   margin-bottom: 16px;

--- a/src/app/components/page-documentation/page-documentation.component.html
+++ b/src/app/components/page-documentation/page-documentation.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <div [ngClass]="classes">
   <div *ngFor="let item of items">

--- a/src/app/components/page-documentation/page-documentation.component.spec.ts
+++ b/src/app/components/page-documentation/page-documentation.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/components/page-documentation/page-documentation.component.ts
+++ b/src/app/components/page-documentation/page-documentation.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, Input, OnInit } from '@angular/core';
 

--- a/src/app/footer/footer.component.css
+++ b/src/app/footer/footer.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 footer {
   width: 100%;

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <footer>
   <p><strong>2DP Repsymo™ Solver</strong></p>

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnInit } from '@angular/core';
 

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 header {
   width: 100%;

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <header>
   <nav>

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import {
   Component,

--- a/src/app/model-file.ts
+++ b/src/app/model-file.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ImComponent } from './page/im/im.component';
 import { WmComponent } from './page/wm/wm.component';

--- a/src/app/page/about/about.component.css
+++ b/src/app/page/about/about.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 :host {
   display: flex;

--- a/src/app/page/about/about.component.html
+++ b/src/app/page/about/about.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <div>
   <div>

--- a/src/app/page/about/about.component.spec.ts
+++ b/src/app/page/about/about.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/page/about/about.component.ts
+++ b/src/app/page/about/about.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnInit } from '@angular/core';
 import { VERSION } from '../../../main';

--- a/src/app/page/im/im.component.css
+++ b/src/app/page/im/im.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 .next-button-container > button {
   width: 25%;

--- a/src/app/page/im/im.component.html
+++ b/src/app/page/im/im.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <app-options-bar
   [examplesNumber]="1"

--- a/src/app/page/im/im.component.spec.ts
+++ b/src/app/page/im/im.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/page/im/im.component.ts
+++ b/src/app/page/im/im.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { IOService } from 'src/service/io.service';

--- a/src/app/page/mrm/mrm-canvas.ts
+++ b/src/app/page/mrm/mrm-canvas.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import {
   Decision,

--- a/src/app/page/mrm/mrm.component.css
+++ b/src/app/page/mrm/mrm.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 #solutionsTreeParent {
   width: 800px;

--- a/src/app/page/mrm/mrm.component.html
+++ b/src/app/page/mrm/mrm.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <app-options-bar
   [examplesNumber]="1"

--- a/src/app/page/mrm/mrm.component.spec.ts
+++ b/src/app/page/mrm/mrm.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/page/mrm/mrm.component.ts
+++ b/src/app/page/mrm/mrm.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnInit } from '@angular/core';
 import {

--- a/src/app/page/page.ts
+++ b/src/app/page/page.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Directive, OnDestroy, OnInit } from '@angular/core';
 import { of, Subscription } from 'rxjs';

--- a/src/app/page/uncertainty/uncertainty.component.css
+++ b/src/app/page/uncertainty/uncertainty.component.css
@@ -1,12 +1,3 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
-
+/* Copyright (c) 2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */

--- a/src/app/page/uncertainty/uncertainty.component.html
+++ b/src/app/page/uncertainty/uncertainty.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <app-options-bar
   [examplesNumber]="1"

--- a/src/app/page/uncertainty/uncertainty.component.spec.ts
+++ b/src/app/page/uncertainty/uncertainty.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/src/app/page/uncertainty/uncertainty.component.ts
+++ b/src/app/page/uncertainty/uncertainty.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnInit } from '@angular/core';
 import {

--- a/src/app/page/wm/wm.component.css
+++ b/src/app/page/wm/wm.component.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 #solutionPanel > .result > .report {
   margin-top: 32px;

--- a/src/app/page/wm/wm.component.html
+++ b/src/app/page/wm/wm.component.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <!-- ---------------------------------------- PAGE OPTIONS ---------------------------------------- -->
 <app-options-bar

--- a/src/app/page/wm/wm.component.spec.ts
+++ b/src/app/page/wm/wm.component.spec.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 

--- a/src/app/page/wm/wm.component.ts
+++ b/src/app/page/wm/wm.component.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import {

--- a/src/app/time-unit.ts
+++ b/src/app/time-unit.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 export interface TimeUnit {
   id: number;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 export const environment = {
   production: true

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.

--- a/src/font.css
+++ b/src/font.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 @font-face {
   font-family: 'Poppins';

--- a/src/index.dev.html
+++ b/src/index.dev.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/src/index.html
+++ b/src/index.html
@@ -1,14 +1,6 @@
-<!--
-  ~ Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
-  ~
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
-  ~
-  ~ This file is part of 2DP Repsymo Solver.
-  ~
-  ~ This source code is licensed under the GNU General Public License v3.0 or
-  ~ later License found in the LICENSE file in the root directory of this source
-  ~ tree or at https://opensource.org/licenses/GPL-3.0.
-  -->
+<!-- Copyright (c) 2019-2022 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<!-- This file is part of https://github.com/repsymo/2dp-repsymo-solver -->
 
 <!DOCTYPE html>
 <html lang="en">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

--- a/src/model/exception.ts
+++ b/src/model/exception.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 export class InvalidModelException extends Error {
   constructor(modelType: string, msg: string) {

--- a/src/model/investment/investment.solver.ts
+++ b/src/model/investment/investment.solver.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Option, Investment } from './investment';
 

--- a/src/model/investment/investment.ts
+++ b/src/model/investment/investment.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 // Experimental model for now
 export interface Investment {

--- a/src/model/machine-replacement/index.ts
+++ b/src/model/machine-replacement/index.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 export * from './machine-replacement';
 export * from './machine-replacement.solver';

--- a/src/model/machine-replacement/machine-replacement.exception.ts
+++ b/src/model/machine-replacement/machine-replacement.exception.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { InvalidModelException } from '../exception';
 

--- a/src/model/machine-replacement/machine-replacement.solver.ts
+++ b/src/model/machine-replacement/machine-replacement.solver.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import {
   Decision,

--- a/src/model/machine-replacement/machine-replacement.ts
+++ b/src/model/machine-replacement/machine-replacement.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { newInvalidModelException } from './machine-replacement.exception';
 

--- a/src/model/uncertainty/uncertainty-solver.ts
+++ b/src/model/uncertainty/uncertainty-solver.ts
@@ -1,11 +1,3 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver

--- a/src/model/uncertainty/uncertainty.ts
+++ b/src/model/uncertainty/uncertainty.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 // Super basic decision-making under uncertainty approaches
 

--- a/src/model/workforce/workforce.solver.ts
+++ b/src/model/workforce/workforce.solver.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { CostOption, Workforce } from './workforce';
 

--- a/src/model/workforce/workforce.ts
+++ b/src/model/workforce/workforce.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 /**
  * Workforce problem model.

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 /**
  * This file includes polyfills needed by Angular and is loaded before the app.

--- a/src/service/io.service.ts
+++ b/src/service/io.service.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+/* Copyright (c) 2019-2022 Tobias Briones. All rights reserved. */
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* This file is part of https://github.com/repsymo/2dp-repsymo-solver */
 
 @import 'font.css';
 

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,14 +1,6 @@
-/*
- * Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This file is part of 2DP Repsymo Solver.
- *
- * This source code is licensed under the GNU General Public License v3.0 or
- * later License found in the LICENSE file in the root directory of this source
- * tree or at https://opensource.org/licenses/GPL-3.0.
- */
+// Copyright (c) 2019-2022 Tobias Briones. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-or-later
+// This file is part of https://github.com/repsymo/2dp-repsymo-solver
 
 // This file is required by karma.conf.js and loads recursively all the .spec
 // and framework files


### PR DESCRIPTION
This is the latest header I've designed to remove legal boilerplate as much as possible and reduce the number of lines it needs as well as a MathSwe standard for open-source code.